### PR TITLE
Feature/bump maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>
+            <version>4.5.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Bump maven dependencies,

[#1](https://github.com/CSUC/wos-times-cited-service/pull/1) Bump httpclient from 4.3.6 to 4.5.6
[#2](https://github.com/CSUC/wos-times-cited-service/pull/2) Bump log4j from 1.2.13 to 1.2.17
[#3](https://github.com/CSUC/wos-times-cited-service/pull/3) Bump json from 20131018 to 20180813
[#4](https://github.com/CSUC/wos-times-cited-service/pull/4) Bump jetty-maven-plugin from 9.0.2.v20130417 to 9.4.14.v20181114
[#5](https://github.com/CSUC/wos-times-cited-service/pull/5) Bump maven-compiler-plugin from 2.3 to 3.8.0
[#6](https://github.com/CSUC/wos-times-cited-service/pull/6) Bump guava from 18.0 to 23.0